### PR TITLE
Ensure transformers version is lower than v4.49.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch>=2.0.1
 tokenizers>=0.14.0
-transformers>=4.36.2
+transformers>=4.36.2, <4.49.0
 accelerate
 attrdict
 tqdm


### PR DESCRIPTION
Ensure transformers version is lower than `v4.49.0`, as the Cache method `get_max_length` is used in [modeling_deepseek.py](https://huggingface.co/deepseek-ai/deepseek-moe-16b-base/blob/main/modeling_deepseek.py#L1382), but was removed in transformers [v4.49.0](https://github.com/huggingface/transformers/releases/tag/v4.49.0) with [PR](https://github.com/huggingface/transformers/pull/35677/files#diff-357aea2fcf1b51b2a8ad17c7d30044159b1fe1a3f6bd832cced70aca84c8be66).